### PR TITLE
Players & Turns

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
     "tasks": [
         {
             "label": "Test",
-            "command": "dotnet test Sharpasonne.Tests",
+            "command": "dotnet test Sharpasonne.Tests && dotnet test Sharpasonne.Model.Tests",
             "type": "shell",
             "group": "test",
             "presentation": {

--- a/Sharpasonne.Tests/EngineTests.cs
+++ b/Sharpasonne.Tests/EngineTests.cs
@@ -42,7 +42,7 @@ namespace Sharpasonne.Tests
         }
 
         [Fact]
-        public void Given_ARuleSetWithANonGameActionKey_When_CreatingAnEngine_Then_None()
+        public void Given_ARuleSetWithANoneGameActionKey_When_CreatingAnEngine_Then_None()
         {
             var ruleSet = new Dictionary<Type, IImmutableList<IRule<IGameAction>>> {
                 [typeof(string)] = ImmutableList.Create<IRule<IGameAction>>(new DummyRule())

--- a/Sharpasonne.Tests/EngineTests.cs
+++ b/Sharpasonne.Tests/EngineTests.cs
@@ -34,7 +34,8 @@ namespace Sharpasonne.Tests
             var engine = Engine
                 .Create(
                     ImmutableQueue<IGameAction>.Empty,
-                    ImmutableDictionary<Type, IImmutableList<IRule<IGameAction>>>.Empty)
+                    ImmutableDictionary<Type, IImmutableList<IRule<IGameAction>>>.Empty,
+                    Players.Create(2).ValueOrFailure())
                 .ValueOrFailure();
 
             Assert.NotNull(engine.Board);
@@ -49,7 +50,8 @@ namespace Sharpasonne.Tests
 
             var option = Engine.Create(
                 ImmutableQueue<IGameAction>.Empty,
-                ruleSet.ToImmutableDictionary());
+                ruleSet.ToImmutableDictionary(),
+                Players.Create(2).ValueOrFailure());
 
             Assert.False(option.HasValue);
             option.MatchNone((exception) => Assert.IsType<ArgumentOutOfRangeException>(exception));
@@ -64,7 +66,8 @@ namespace Sharpasonne.Tests
 
             var option = Engine.Create(
                 ImmutableQueue<IGameAction>.Empty,
-                ruleSet.ToImmutableDictionary());
+                ruleSet.ToImmutableDictionary(),
+                Players.Create(2).ValueOrFailure());
 
             Assert.True(option.HasValue);
         }
@@ -77,7 +80,12 @@ namespace Sharpasonne.Tests
                 [typeof(PlaceTileGameAction)] = ImmutableList<IRule<IGameAction>>.Empty
             };
 
-            var engine = Engine.Create(rules.ToImmutableDictionary()).ValueOrFailure();
+            var engine = Engine
+                .Create(
+                    ImmutableQueue<IGameAction>.Empty,
+                    rules.ToImmutableDictionary(),
+                    Players.Create(2).ValueOrFailure())
+                .ValueOrFailure();
 
             // Act
             var newState = engine.Perform(MakePlaceTile(0, 0));
@@ -94,7 +102,12 @@ namespace Sharpasonne.Tests
                 [typeof(PlaceTileGameAction)] = ImmutableList<IRule<IGameAction>>.Empty
             };
 
-            var engine = Engine.Create(rules.ToImmutableDictionary()).ValueOrFailure();
+            var engine = Engine
+                .Create(
+                    ImmutableQueue<IGameAction>.Empty,
+                    rules.ToImmutableDictionary(),
+                    Players.Create(2).ValueOrFailure())
+                .ValueOrFailure();
 
             // Act
             var newState = engine.Perform(MakePlaceTile(0, 0));

--- a/Sharpasonne.Tests/Engine_PlayerTests.cs
+++ b/Sharpasonne.Tests/Engine_PlayerTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Optional.Unsafe;
+using Sharpasonne.GameActions;
+using Sharpasonne.Models;
+using Sharpasonne.Rules;
+using Sharpasonne.Tests.Rules;
+using Moq;
+using Xunit;
+
+namespace Sharpasonne.Tests
+{
+    public class Engine_PlayerTests : UnitTest<PlaceTileGameAction>
+    {
+        protected Engine CreateEngine(int players)
+        {
+            var mockPlayers = new Mock<Players>();
+
+            mockPlayers.SetupGet(e => e.Count).Returns(players);
+
+            var option = Engine.Create(
+                ImmutableQueue<IGameAction>.Empty,
+                new Dictionary<Type, IImmutableList<IRule<IGameAction>>> {
+                    [typeof(PlaceTileGameAction)] = ImmutableList<IRule<IGameAction>>.Empty
+                }.ToImmutableDictionary(),
+                mockPlayers.Object
+            );
+
+            return option.ValueOrFailure();
+        }
+
+        [Fact]
+        public void Given_2Players_When_FirstTurn_Then_NextPlayerIsFirstPlayer()
+        {
+            Assert.Equal(1, CreateEngine(players: 2).CurrentPlayerTurn);
+        }
+
+        [Fact]
+        public void Given_2Players_When_SecondTurn_Then_NextPlayerIsSecondPlayer()
+        {
+            var firstTurn = CreateEngine(2);
+            var secondTurn = firstTurn.Perform(MakePlaceTile(0, 0)).ValueOrFailure();
+            Assert.Equal(2, secondTurn.CurrentPlayerTurn);
+        }
+
+        [Fact]
+        public void Given_2Players_When_ThirdTurn_Then_NextPlayerIsFirstPlayerAgain()
+        {
+            var firstTurn = CreateEngine(2);
+            var secondTurn = firstTurn.Perform(MakePlaceTile(0, 0)).ValueOrFailure();
+            var thirdTurn = secondTurn.Perform(MakePlaceTile(0, 1)).ValueOrFailure();
+            Assert.Equal(1, thirdTurn.CurrentPlayerTurn);
+        }
+    }
+}

--- a/Sharpasonne.Tests/PlayersTests.cs
+++ b/Sharpasonne.Tests/PlayersTests.cs
@@ -35,5 +35,25 @@ namespace Sharpasonne.Tests
         {
             Players.Create(6).MatchNone(exception => Assert.IsType<ArgumentOutOfRangeException>(exception));
         }
+
+        [Fact]
+        public void Given_NumberOutsideRange_When_FindingNextPlayer_Then_Is1()
+        {
+            Assert.Equal(1, Players.Create(2).ValueOrFailure().NextPlayer(0));
+            Assert.Equal(1, Players.Create(2).ValueOrFailure().NextPlayer(3));
+        }
+
+        [Fact]
+        public void Given_Player1_When_FindingNextPlayer_Then_Is2()
+        {
+            Assert.Equal(2, Players.Create(2).ValueOrFailure().NextPlayer(1));
+        }
+
+        [Fact]
+        public void Given_LastPlayerInBound_When_FindingNextPlayer_Then_Is1()
+        {
+            int count = 4;
+            Assert.Equal(1, Players.Create(count).ValueOrFailure().NextPlayer(count));
+        }
     }
 }

--- a/Sharpasonne.Tests/PlayersTests.cs
+++ b/Sharpasonne.Tests/PlayersTests.cs
@@ -13,13 +13,13 @@ namespace Sharpasonne.Tests
     public class PlayersTests : UnitTest<PlaceTileGameAction>
     {
         [Fact]
-        public void Given_ZeroPlayers_When_CreatingPlayers_Then_NonIsArgumentOutOfRangeException()
+        public void Given_ZeroPlayers_When_CreatingPlayers_Then_NoneIsArgumentOutOfRangeException()
         {
             Players.Create(0).MatchNone(exception => Assert.IsType<ArgumentOutOfRangeException>(exception));
         }
 
         [Fact]
-        public void Given_1Player_When_CreatingPlayers_Then_NonIsArgumentOutOfRangeException()
+        public void Given_1Player_When_CreatingPlayers_Then_NoneIsArgumentOutOfRangeException()
         {
             Players.Create(1).MatchNone(exception => Assert.IsType<ArgumentOutOfRangeException>(exception));
         }
@@ -31,7 +31,7 @@ namespace Sharpasonne.Tests
         }
 
         [Fact]
-        public void Given_6Players_When_CreatingPlayers_Then_NonIsArgumentOutOfRangeException()
+        public void Given_6Players_When_CreatingPlayers_Then_NoneIsArgumentOutOfRangeException()
         {
             Players.Create(6).MatchNone(exception => Assert.IsType<ArgumentOutOfRangeException>(exception));
         }

--- a/Sharpasonne.Tests/PlayersTests.cs
+++ b/Sharpasonne.Tests/PlayersTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Optional.Unsafe;
+using Sharpasonne.GameActions;
+using Sharpasonne.Models;
+using Sharpasonne.Rules;
+using Sharpasonne.Tests.Rules;
+using Xunit;
+
+namespace Sharpasonne.Tests
+{
+    public class PlayersTests : UnitTest<PlaceTileGameAction>
+    {
+        [Fact]
+        public void Given_ZeroPlayers_When_CreatingPlayers_Then_NonIsArgumentOutOfRangeException()
+        {
+            Players.Create(0).MatchNone(exception => Assert.IsType<ArgumentOutOfRangeException>(exception));
+        }
+
+        [Fact]
+        public void Given_1Player_When_CreatingPlayers_Then_NonIsArgumentOutOfRangeException()
+        {
+            Players.Create(1).MatchNone(exception => Assert.IsType<ArgumentOutOfRangeException>(exception));
+        }
+
+        [Fact]
+        public void Given_2Players_When_CreatingPlayers_Then_SomeIsReturned()
+        {
+            Assert.NotNull(Players.Create(2).ValueOrFailure());
+        }
+
+        [Fact]
+        public void Given_6Players_When_CreatingPlayers_Then_NonIsArgumentOutOfRangeException()
+        {
+            Players.Create(6).MatchNone(exception => Assert.IsType<ArgumentOutOfRangeException>(exception));
+        }
+    }
+}

--- a/Sharpasonne/Engine.cs
+++ b/Sharpasonne/Engine.cs
@@ -18,13 +18,21 @@ namespace Sharpasonne
         public IImmutableDictionary<Type, IImmutableList<IRule<IGameAction>>> Rules { get; }
             = ImmutableDictionary<Type, IImmutableList<IRule<IGameAction>>>.Empty;
 
-        /// <summary>
-        /// 
-        /// </summary>
+
         /// <param name="gameActions"></param>
         /// <param name="rules">Must provide list for every action to be used by
         /// Perform.</param>
-        public Engine(
+        public static Option<Engine, Exception> Create(
+            [NotNull] IImmutableDictionary<Type, IImmutableList<IRule<IGameAction>>> rules)
+        {
+            return Engine.Create(ImmutableQueue<IGameAction>.Empty, rules);
+        }
+
+        /// <param name="gameActions"></param>
+        /// <param name="rules">Must provide list for every action to be used by
+        /// Perform.</param>
+        public static Option<Engine, Exception> Create(
+            [NotNull] IImmutableQueue<IGameAction>                                   gameActions,
             [NotNull] IImmutableDictionary<Type, IImmutableList<IRule<IGameAction>>> rules)
         {
             var nonGameActions = rules.Keys
@@ -35,17 +43,17 @@ namespace Sharpasonne
             {
                 var typeNames = string.Join(", ", nonGameActions.Select(t => t.FullName));
                 var message = $"'{typeNames}' does not implement {nameof(IGameAction)}";
-                throw new ArgumentOutOfRangeException(message);
+                return Option.None<Engine, Exception>(new ArgumentOutOfRangeException(nameof(gameActions), message));
             }
 
-            this.Rules = rules;
+            return Option.Some<Engine, Exception>(new Engine(gameActions, rules));
         }
 
-        public Engine(
+        private Engine(
             [NotNull] IImmutableQueue<IGameAction>                                   gameActions,
             [NotNull] IImmutableDictionary<Type, IImmutableList<IRule<IGameAction>>> rules)
-            : this(rules)
         {
+            this.Rules = rules;
         }
 
         private Engine(IEngine engine)

--- a/Sharpasonne/GameActions/PlaceTileGameAction.cs
+++ b/Sharpasonne/GameActions/PlaceTileGameAction.cs
@@ -19,19 +19,23 @@ namespace Sharpasonne.GameActions
         public IEngine Perform(IEngine engine)
         {
             var board = engine.Board.Set(Placement.Tile, Point, Placement.Orientation);
-            return new EngineState(board, engine.Rules);
+            return new EngineState(board, engine);
         }
     }
 
     public class EngineState : IEngine
     {
-        public EngineState(Board board, IImmutableDictionary<Type, IImmutableList<IRule<IGameAction>>> rules)
+        public EngineState(Board board, IEngine engine)
         {
-            Board = board;
-            Rules = rules;
+            this.Board = board;
+            this.Rules = engine.Rules;
+            this.Players = engine.Players;
+            this.CurrentPlayerTurn = engine.CurrentPlayerTurn;
         }
 
         public Board Board { get; }
+        public Players Players { get; }
+        public int CurrentPlayerTurn { get; }
         public IImmutableDictionary<Type, IImmutableList<IRule<IGameAction>>> Rules { get; }
     }
 }

--- a/Sharpasonne/IEngine.cs
+++ b/Sharpasonne/IEngine.cs
@@ -9,6 +9,8 @@ namespace Sharpasonne
     public interface IEngine
     {
         Board Board { get; }
+        Players Players { get; }
+        int CurrentPlayerTurn { get; }
         IImmutableDictionary<Type, IImmutableList<IRule<IGameAction>>> Rules { get; }
     }
 }

--- a/Sharpasonne/Players.cs
+++ b/Sharpasonne/Players.cs
@@ -31,7 +31,7 @@ namespace Sharpasonne
         /// Number of players, always within the inclusive range <see cref="LOWER_BOUND" />...
         /// <see cref="UPPER_BOUND" />.
         /// </summary>
-        public int Count { get; }
+        public virtual int Count { get; }
 
         /// <summary>
         /// Attempts to create a <see cref="Players" /> instance, fails and returns a none if
@@ -53,12 +53,44 @@ namespace Sharpasonne
         }
 
         /// <summary>
+        /// Creates a <see cref="Players" /> instance with <see cref="LOWER_BOUND" /> number
+        /// of players. This is only intended for use with Moq, yse <see cref="Create(int)" />
+        /// instead.
+        /// </summary>
+        protected Players() : this(LOWER_BOUND)
+        {
+        }
+
+        /// <summary>
         /// Creates a <see cref="Players" /> instance without doing any checks for consistency of
         /// <paramref name="count" /> argument. Use <see cref="Create(int)" /> instead.
         /// </summary>
         protected Players(int count)
         {
             this.Count = count;
+        }
+
+        /// <summary>
+        /// Gets the next player after the given <paramref name="player" /> cycling around from
+        /// last to first:
+        /// <example>
+        /// Assert.Equals(1, Players.Create(2).NextPlayer(2));
+        /// </example>
+        /// If <paramref name="players" /> is outside the number of players, 1 is always returned.
+        /// </summary>
+        /// <param name="player">1-index number of the player.</param>
+        /// <returns>1-index number of the next player.</returns>
+        public int NextPlayer(int player)
+        {
+            if (!Enumerable.Range(1, this.Count).Contains(player)) {
+                return 1;
+            }
+
+            // As the player's number is 1-indexed we can mod by the total number of players to
+            // cycle around from the end getting the next player's 0-indexed number. Then add 1
+            // to whatever value this is.
+            // E.g. in a 4 player games player 4 => 4%4 = 0, add 1 => player 1.
+            return (player % this.Count) + 1;
         }
     }
 }

--- a/Sharpasonne/Players.cs
+++ b/Sharpasonne/Players.cs
@@ -13,38 +13,38 @@ namespace Sharpasonne
     public class Players
     {
         /// <summary>
-        /// Least number of players allowed to create a <see cref="Players" /> instance.
+        /// Fewest number of players allowed to create a <see cref="Players" /> instance.
         /// </summary>
-        public const int LOWER_BOUND = 2;
+        public const int FewestPlayers = 2;
 
         /// <summary>
         /// Most number of players allowed to create a <see cref="Players" /> instance.
         /// </summary>
-        public const int UPPER_BOUND = 5;
+        public const int MostPlayers = 5;
 
         /// <summary>
         /// Range size of the lower and upper bound.
         /// </summary>
-        protected const int RANGE_SIZE = (UPPER_BOUND - LOWER_BOUND);
+        protected const int PlayerRangeSize = (MostPlayers - FewestPlayers);
 
         /// <summary>
-        /// Number of players, always within the inclusive range <see cref="LOWER_BOUND" />...
-        /// <see cref="UPPER_BOUND" />.
+        /// Number of players, always within the inclusive range <see cref="FewestPlayers" />...
+        /// <see cref="MostPlayers" />.
         /// </summary>
         public virtual int Count { get; }
 
         /// <summary>
         /// Attempts to create a <see cref="Players" /> instance, fails and returns a none if
-        /// <paramref name="count" /> is outside the inclusive player range <see cref="LOWER_BOUND" />
-        /// ...<see cref="UPPER_BOUND" />.
+        /// <paramref name="count" /> is outside the inclusive player range <see cref="FewestPlayers" />
+        /// ...<see cref="MostPlayers" />.
         /// </summary>
         public static Option<Players, Exception> Create(int count)
         {
-            if (!Enumerable.Range(LOWER_BOUND, RANGE_SIZE).Contains(count)) {
+            if (!Enumerable.Range(FewestPlayers, PlayerRangeSize).Contains(count)) {
                 return Option.None<Players, Exception>(
                     new ArgumentOutOfRangeException(
                         nameof(count),
-                        $"must be in the inclusive range ${LOWER_BOUND}-${UPPER_BOUND}."
+                        $"must be in the inclusive range ${FewestPlayers}-${MostPlayers}."
                     )
                 );
             }
@@ -53,11 +53,11 @@ namespace Sharpasonne
         }
 
         /// <summary>
-        /// Creates a <see cref="Players" /> instance with <see cref="LOWER_BOUND" /> number
+        /// Creates a <see cref="Players" /> instance with <see cref="FewestPlayers" /> number
         /// of players. This is only intended for use with Moq, yse <see cref="Create(int)" />
         /// instead.
         /// </summary>
-        protected Players() : this(LOWER_BOUND)
+        protected Players() : this(FewestPlayers)
         {
         }
 

--- a/Sharpasonne/Players.cs
+++ b/Sharpasonne/Players.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using JetBrains.Annotations;
+using Optional;
+using Sharpasonne.GameActions;
+using Sharpasonne.Models;
+using Sharpasonne.Rules;
+
+namespace Sharpasonne
+{
+    public class Players
+    {
+        /// <summary>
+        /// Least number of players allowed to create a <see cref="Players" /> instance.
+        /// </summary>
+        public const int LOWER_BOUND = 2;
+
+        /// <summary>
+        /// Most number of players allowed to create a <see cref="Players" /> instance.
+        /// </summary>
+        public const int UPPER_BOUND = 5;
+
+        /// <summary>
+        /// Range size of the lower and upper bound.
+        /// </summary>
+        protected const int RANGE_SIZE = (UPPER_BOUND - LOWER_BOUND);
+
+        /// <summary>
+        /// Number of players, always within the inclusive range <see cref="LOWER_BOUND" />...
+        /// <see cref="UPPER_BOUND" />.
+        /// </summary>
+        public int Count { get; }
+
+        /// <summary>
+        /// Attempts to create a <see cref="Players" /> instance, fails and returns a none if
+        /// <paramref name="count" /> is outside the inclusive player range <see cref="LOWER_BOUND" />
+        /// ...<see cref="UPPER_BOUND" />.
+        /// </summary>
+        public static Option<Players, Exception> Create(int count)
+        {
+            if (!Enumerable.Range(LOWER_BOUND, RANGE_SIZE).Contains(count)) {
+                return Option.None<Players, Exception>(
+                    new ArgumentOutOfRangeException(
+                        nameof(count),
+                        $"must be in the inclusive range ${LOWER_BOUND}-${UPPER_BOUND}."
+                    )
+                );
+            }
+
+            return Option.Some<Players, Exception>(new Players(count));
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Players" /> instance without doing any checks for consistency of
+        /// <paramref name="count" /> argument. Use <see cref="Create(int)" /> instead.
+        /// </summary>
+        protected Players(int count)
+        {
+            this.Count = count;
+        }
+    }
+}


### PR DESCRIPTION
Resolves #4 by adding a `Players` class which understands player counts and turn order. The next player number is then available on an engine as `Engine#CurrentPlayerTurn` (name isn't set it stone obviously!)

N.B.:
 - players are represented as 1-indexed ints.
 - this PR branches off my other PR #12. The other will need merging first, then I'll rebase back off master 👍 